### PR TITLE
Always retry alternatives.install states

### DIFF
--- a/phpstorm/linuxenv.sls
+++ b/phpstorm/linuxenv.sls
@@ -31,6 +31,9 @@ phpstorm-home-alt-install:
     - link: '{{ phpstorm.jetbrains.home }}/phpstorm'
     - path: '{{ phpstorm.jetbrains.realhome }}'
     - priority: {{ phpstorm.linux.altpriority }}
+    - retry:
+        attempts: 2
+        until: True
 
 phpstorm-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ phpstorm-home-alt-set:
     - path: {{ phpstorm.jetbrains.realhome }}
     - onchanges:
       - alternatives: phpstorm-home-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
 # Add to alternatives system
 phpstorm-alt-install:
@@ -49,6 +55,9 @@ phpstorm-alt-install:
     - require:
       - alternatives: phpstorm-home-alt-install
       - alternatives: phpstorm-home-alt-set
+    - retry:
+        attempts: 2
+        until: True
 
 phpstorm-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ phpstorm-alt-set:
     - path: {{ phpstorm.jetbrains.realcmd }}
     - onchanges:
       - alternatives: phpstorm-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
   {% endif %}
 

--- a/phpstorm/map.jinja
+++ b/phpstorm/map.jinja
@@ -22,10 +22,10 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
-{% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None', '',) %}
-   {%- set pcode = ide.jetbrains.product %}
-{% endif %}
+{%- set pcode = ide.jetbrains.product %}
+{%- if grains.os != 'MacOS' %}
+    {%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
+{%- endif %}
 {%- set jdata = salt['cmd.run']('curl {0} {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 
 # Extract download details


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` sometimes fails on 1st run.

Verified on SuSE